### PR TITLE
Track LexiBlaster personal bests and refresh sharing flow

### DIFF
--- a/lexiblaster/consent.js
+++ b/lexiblaster/consent.js
@@ -60,6 +60,7 @@
     if (choice === 'reject') {
       try { localStorage.removeItem('lb_scores_v1'); } catch {}
       try { localStorage.removeItem('bgmMuted'); } catch {}
+      try { localStorage.removeItem('LBBackup'); } catch {}
     }
 
     // 必ず閉じる


### PR DESCRIPTION
## Summary
- persist the highest score in the LBBackup profile and report personal-best status at game over
- display a PB badge and richer metadata in the scoreboard overlay while surfacing streak information
- rewrite the share message flow with one-line output, consent-aware URLs, and clipboard fallback

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d0eca1ac1c832b84ff1cf8be022366