### PR TITLE
Add vertical leaderboard UI and ranking hub

### DIFF
--- a/assets/load-header.js
+++ b/assets/load-header.js
@@ -13,7 +13,10 @@
     hostHeader.innerHTML = `
       <div class="nav">
         <a class="brand" href="/"><div class="logo">IT</div><strong>Irori's Toybox</strong></a>
-        <nav><a class="link" href="/">Home</a></nav>
+        <nav>
+          <a class="link" href="/">Home</a>
+          <a class="link" href="/leaderboards/">ランキング</a>
+        </nav>
       </div>`;
     return;
   }

--- a/index.html
+++ b/index.html
@@ -146,6 +146,7 @@
           <span class="sub">PC推奨／キーボード操作</span>
         </a>
         <a class="btn" href="/changelog/">📝 更新履歴を見る</a>
+        <a class="btn" href="/leaderboards/">🏆 ランキングを見る</a>
       </div>
     </section>
 
@@ -166,6 +167,7 @@
         <div class="cta-row" style="margin-top:12px;display:flex;gap:12px;flex-wrap:wrap">
           <a class="btn primary" href="/lexiblaster/">▶ 今すぐプレイ</a>
           <a class="btn" href="/changelog/">📝 更新履歴</a>
+          <a class="btn" href="/leaderboards/">🏆 ランキング</a>
         </div>
         <a class="hero-thumb" href="/lexiblaster/" aria-label="Lexi Blaster をプレイ">
           <picture>
@@ -200,6 +202,7 @@
 
     <footer>
       <div class="links">
+        <a href="/leaderboards/">ランキング</a>
         <a href="/privacy/">プライバシーポリシー</a>
         <a href="/cookie-policy/">クッキーポリシー</a>
         <a href="/contact/">お問い合わせ</a>

--- a/leaderboards/index.html
+++ b/leaderboards/index.html
@@ -1,0 +1,107 @@
+<!doctype html><html lang="ja"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Leaderboards | Irori's Toybox</title>
+<meta name="description" content="Irori's Toybox のゲームランキング一覧。Lexi Blaster のトップスコアをチェックしよう。">
+<link rel="stylesheet" href="/assets/site.css">
+<script src="/assets/load-header.js" defer></script>
+<style>
+:root{ --bg:#0b1520; --panel:#121c28; --panel2:#0f1d2a; --txt:#e6f2ff; --muted:#9ab6c9; --acc:#5cd4ff; --border:#203447 }
+*{ box-sizing:border-box }
+body{ margin:0; background:var(--bg); color:var(--txt); font:16px/1.7 system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif; }
+a{ color:var(--acc); text-decoration:none } a:hover{ text-decoration:underline }
+main{ width:min(960px,92vw); margin:28px auto 80px }
+.hero{ background:linear-gradient(180deg,rgba(18,28,40,.92),rgba(12,22,34,.92)); border:1px solid var(--border); border-radius:18px; padding:28px; margin-bottom:24px; box-shadow:0 18px 40px rgba(0,0,0,.32) }
+.hero h1{ margin:0 0 10px; font-size:clamp(24px,4vw,32px); letter-spacing:.03em }
+.hero p{ margin:0; color:var(--muted) }
+.card{ background:var(--panel); border:1px solid var(--border); border-radius:16px; padding:20px; margin-bottom:24px; box-shadow:0 14px 36px rgba(0,0,0,.28) }
+.card h2{ margin:0 0 12px; font-size:22px; letter-spacing:.02em }
+.card .lead{ margin:0 0 14px; color:var(--muted) }
+.lb-vertical{ padding:14px; border:1px solid rgba(255,255,255,.08); border-radius:12px; background:var(--panel2) }
+.lb-status{ font-size:14px; margin:0 0 10px; }
+.lb-status--info{ color:#bcd9ff }
+.lb-status--loading{ color:#9ad0ff }
+.lb-status--success{ color:#8ef59d }
+.lb-status--error{ color:#ff8e8e }
+.lb-status--warning{ color:#ffd27d }
+.lb-list{ list-style:none; padding:0; margin:0 }
+.lb-list li{ display:flex; align-items:baseline; gap:10px; padding:8px 4px; border-top:1px solid rgba(255,255,255,.08); font-size:14px }
+.lb-list li:first-child{ border-top:none }
+.lb-rank{ font-weight:700; min-width:3.4em }
+.lb-name{ flex:1 1 auto; overflow:hidden; text-overflow:ellipsis; white-space:nowrap }
+.lb-score{ color:var(--muted) }
+.lb-list li.lb-row-self{ background:rgba(92,212,255,.10); border-radius:6px; padding:8px 12px }
+.lb-row-self{ background:rgba(92,212,255,.10); border-radius:6px }
+footer{ margin-top:40px; padding-top:18px; border-top:1px solid var(--border); color:var(--muted); display:flex; flex-wrap:wrap; gap:12px; justify-content:space-between }
+footer .links a{ margin-right:14px }
+@media (max-width:640px){
+  .hero{ padding:22px }
+  .card{ padding:18px }
+  .lb-list li{ font-size:13px }
+}
+</style>
+</head><body>
+<header class="site" id="site-header" hidden></header>
+<main>
+  <section class="hero">
+    <h1>Leaderboards</h1>
+    <p>Irori's Toybox で公開中のゲームランキングをまとめました。まずは Lexi Blaster のスコアをチェック！</p>
+  </section>
+
+  <section class="card" data-game="lexi-blaster">
+    <h2>Lexi Blaster — TOP 20</h2>
+    <p class="lead">英単語タイピングゲームの最新ランキング。あなたのハイスコアもここに刻もう。</p>
+    <div id="lb-embed" class="lb-vertical" hidden>
+      <div id="lb-embed-status" class="lb-status" hidden></div>
+      <ol id="lb-embed-list" class="lb-list"></ol>
+    </div>
+  </section>
+
+  <footer>
+    <div class="links">
+      <a href="/leaderboards/">ランキング</a>
+      <a href="/lexiblaster/">Lexi Blaster</a>
+      <a href="/changelog/">更新履歴</a>
+      <a href="/contact/">お問い合わせ</a>
+    </div>
+    <div>&copy; <span id="lb-year"></span> Irori</div>
+  </footer>
+</main>
+
+<script>window.LEXI_LEADERBOARD_BASE = 'https://lb.irori-toybox.com';</script>
+<script src="/lexiblaster/leaderboard.js" defer></script>
+<script>
+(function(){
+  const limit = 20;
+  const root = document.getElementById('lb-embed');
+  const statusEl = document.getElementById('lb-embed-status');
+  const listEl = document.getElementById('lb-embed-list');
+  const setYear = () => { const y = document.getElementById('lb-year'); if (y) y.textContent = new Date().getFullYear(); };
+  setYear();
+  const boot = async () => {
+    if (!window.lexiLeaderboard || !root || !statusEl || !listEl) return;
+    const { fetchLeaderboard, renderVerticalList, setStatusElement } = window.lexiLeaderboard;
+    try {
+      setStatusElement(statusEl, '読み込み中…', 'loading');
+      root.hidden = false;
+      listEl.innerHTML = '';
+      const entries = await fetchLeaderboard(limit);
+      renderVerticalList(root, entries, { list: listEl, status: statusEl, limit });
+    } catch (err) {
+      console.error('[leaderboards] fetch failed', err);
+      renderVerticalList(root, [], {
+        list: listEl,
+        status: statusEl,
+        limit,
+        emptyMessage: '取得に失敗しました。時間をおいて再度お試しください。',
+        emptyStatusType: 'error'
+      });
+    }
+  };
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', boot, { once: true });
+  } else {
+    boot();
+  }
+})();
+</script>
+</body></html>

--- a/lexiblaster/score.js
+++ b/lexiblaster/score.js
@@ -176,9 +176,23 @@
       .lb-status--success{color:#8ef59d;}
       .lb-status--error{color:#ff8e8e;}
       .lb-status--warning{color:#ffd27d;}
+      .lb-layout{display:flex;flex-wrap:wrap;gap:20px;align-items:flex-start;}
+      .lb-primary{flex:1 1 320px;min-width:260px;}
+      .lb-vertical{flex:1 1 220px;min-width:200px;padding:12px;border:1px solid rgba(255,255,255,.08);border-radius:10px;background:rgba(255,255,255,.03);}
+      .lb-vertical-heading{margin:0 0 6px;font-size:14px;font-weight:700;letter-spacing:.3px;color:#bcd9ff;}
+      .lb-vertical .lb-status{margin:0 0 8px 0;}
+      .lb-list{list-style:none;padding:0;margin:0;}
+      .lb-list li{display:flex;align-items:baseline;gap:8px;padding:6px 0;border-top:1px solid rgba(255,255,255,.08);font-size:13px;}
+      .lb-list li:first-child{border-top:none;}
+      .lb-list li .lb-rank{min-width:3.2em;}
+      .lb-rank{font-weight:700;margin-right:8px;}
+      .lb-name{margin-right:8px;flex:1 1 auto;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+      .lb-score{color:#9ab6c9;}
       .lb-table th:nth-child(3),.lb-table td:nth-child(3){text-align:right;}
       .lb-table td:nth-child(2){max-width:220px;overflow:hidden;text-overflow:ellipsis;}
-      .lb-row-self{background:rgba(76,175,80,.18);}
+      .lb-table tr.lb-row-self td{background:rgba(92,212,255,.10);}
+      .lb-list li.lb-row-self{background:rgba(92,212,255,.10);border-radius:6px;padding:6px 10px;}
+      .lb-row-self{background:rgba(92,212,255,.10);border-radius:6px;}
       `;
       const st = document.createElement('style');
       st.id = 'lexi-scoreboard-style';
@@ -215,19 +229,28 @@
 
           <div class="lexi-leaderboard" id="lb-leaderboard" hidden>
             <h3>オンラインランキング</h3>
-            <p class="lb-status" id="lb-leaderboard-status" aria-live="polite">ハイスコアを登録してランキングに参加しよう！</p>
-            <form class="lexi-leaderboard-form" id="lb-leaderboard-form">
-              <label for="lb-leaderboard-name">ハンドルネーム（1〜12文字）</label>
-              <div class="lexi-leaderboard-inputs">
-                <input type="text" id="lb-leaderboard-name" name="name" maxlength="12" autocomplete="nickname" required />
-                <button type="submit" class="lexi-btn tertiary" id="lb-leaderboard-submit">スコア登録</button>
+            <div class="lb-layout">
+              <div class="lb-primary">
+                <p class="lb-status" id="lb-leaderboard-status" aria-live="polite">ハイスコアを登録してランキングに参加しよう！</p>
+                <form class="lexi-leaderboard-form" id="lb-leaderboard-form">
+                  <label for="lb-leaderboard-name">ハンドルネーム（1〜12文字）</label>
+                  <div class="lexi-leaderboard-inputs">
+                    <input type="text" id="lb-leaderboard-name" name="name" maxlength="12" autocomplete="nickname" required />
+                    <button type="submit" class="lexi-btn tertiary" id="lb-leaderboard-submit">スコア登録</button>
+                  </div>
+                </form>
+                <table class="lexi-sb-table lb-table" id="lb-leaderboard-table">
+                  <thead><tr><th>Rank</th><th>Name</th><th>Score</th></tr></thead>
+                  <tbody id="lb-leaderboard-body"></tbody>
+                </table>
+                <p class="lexi-note" id="lb-leaderboard-empty" hidden>まだ登録がありません。最初の挑戦者になろう！</p>
               </div>
-            </form>
-            <table class="lexi-sb-table lb-table" id="lb-leaderboard-table">
-              <thead><tr><th>Rank</th><th>Name</th><th>Score</th></tr></thead>
-              <tbody id="lb-leaderboard-body"></tbody>
-            </table>
-            <p class="lexi-note" id="lb-leaderboard-empty" hidden>まだ登録がありません。最初の挑戦者になろう！</p>
+              <aside id="lb-vertical" class="lb-vertical" hidden>
+                <p class="lb-vertical-heading">TOP 20</p>
+                <div id="lb-vertical-status" class="lb-status" hidden></div>
+                <ol id="lb-vertical-list" class="lb-list"></ol>
+              </aside>
+            </div>
           </div>
 
           <div class="lexi-sb-actions">
@@ -322,7 +345,7 @@
       this.el.style.display = 'grid';
 
       const leaderboardRoot = this.el.querySelector('#lb-leaderboard');
-      this._dispatchLeaderboard('show', { tracker, meta, total, root: leaderboardRoot });
+      this._dispatchLeaderboard('show', { tracker, meta, total, root: leaderboardRoot, limit: 20 });
     }
 
     hide() {

--- a/partials/header.html
+++ b/partials/header.html
@@ -3,6 +3,7 @@
   <nav>
     <a class="link" data-path="/"               href="/">Home</a>
     <a class="link" data-path="/lexiblaster/"   href="/lexiblaster/">Lexi Blaster</a>
+    <a class="link" data-path="/leaderboards/"  href="/leaderboards/">ランキング</a>
     <a class="link" data-path="/changelog/"     href="/changelog/">更新履歴</a>
     <a class="link" data-path="/privacy/"       href="/privacy/">プライバシー</a>
     <a class="link" data-path="/cookie-policy/" href="/cookie-policy/">クッキー</a>


### PR DESCRIPTION
## Summary
- extend the Lexi Blaster results overlay with a side-by-side vertical TOP20 list and styling updates
- enhance leaderboard.js with reusable vertical rendering, improved status handling, and self-entry highlighting
- add a /leaderboards/ page plus navigation links to surface rankings across the site

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d135bde7f4832b9c37910ec6c37ff5