### PR TITLE
Add mode-aware Lexi Blaster leaderboards

### DIFF
--- a/assets/load-header.js
+++ b/assets/load-header.js
@@ -15,7 +15,7 @@
         <a class="brand" href="/"><div class="logo">IT</div><strong>Irori's Toybox</strong></a>
         <nav>
           <a class="link" href="/">Home</a>
-          <a class="link" href="/leaderboards/">ランキング</a>
+          <a class="link" href="/leaderboard/">ランキング</a>
         </nav>
       </div>`;
     return;

--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@
           <span class="sub">PC推奨／キーボード操作</span>
         </a>
         <a class="btn" href="/changelog/">📝 更新履歴を見る</a>
-        <a class="btn" href="/leaderboards/">🏆 ランキングを見る</a>
+        <a class="btn" href="/leaderboard/">🏆 ランキングを見る</a>
       </div>
     </section>
 
@@ -167,7 +167,7 @@
         <div class="cta-row" style="margin-top:12px;display:flex;gap:12px;flex-wrap:wrap">
           <a class="btn primary" href="/lexiblaster/">▶ 今すぐプレイ</a>
           <a class="btn" href="/changelog/">📝 更新履歴</a>
-          <a class="btn" href="/leaderboards/">🏆 ランキング</a>
+          <a class="btn" href="/leaderboard/">🏆 ランキング</a>
         </div>
         <a class="hero-thumb" href="/lexiblaster/" aria-label="Lexi Blaster をプレイ">
           <picture>
@@ -202,7 +202,7 @@
 
     <footer>
       <div class="links">
-        <a href="/leaderboards/">ランキング</a>
+        <a href="/leaderboard/">ランキング</a>
         <a href="/privacy/">プライバシーポリシー</a>
         <a href="/cookie-policy/">クッキーポリシー</a>
         <a href="/contact/">お問い合わせ</a>

--- a/leaderboard/index.html
+++ b/leaderboard/index.html
@@ -1,0 +1,264 @@
+<!doctype html><html lang="ja"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>ランキング – Irori's Toybox</title>
+<meta name="description" content="英単語タイピングゲーム Lexi Blaster のオンラインランキング。モードと言語レベル別のトップスコアをチェックしよう。">
+<link rel="canonical" href="https://irori-toybox.com/leaderboard/">
+<meta property="og:title" content="ランキング – Irori's Toybox">
+<meta property="og:description" content="英単語タイピングゲーム Lexi Blaster のオンラインランキング。モードと言語レベル別のトップスコアをチェックしよう。">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://irori-toybox.com/leaderboard/">
+<link rel="stylesheet" href="/assets/site.css">
+<script src="/assets/load-header.js" defer></script>
+<style>
+:root{ --bg:#0b1520; --panel:#121c28; --panel2:#0f1d2a; --txt:#e6f2ff; --muted:#9ab6c9; --acc:#5cd4ff; --border:#203447 }
+*{ box-sizing:border-box }
+body{ margin:0; background:var(--bg); color:var(--txt); font:16px/1.7 system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif; }
+a{ color:var(--acc); text-decoration:none } a:hover{ text-decoration:underline }
+main{ width:min(980px,92vw); margin:28px auto 84px }
+.hero{ background:linear-gradient(180deg,rgba(18,28,40,.92),rgba(12,22,34,.92)); border:1px solid var(--border); border-radius:18px; padding:32px; margin-bottom:26px; box-shadow:0 18px 40px rgba(0,0,0,.32) }
+.hero h1{ margin:0 0 12px; font-size:clamp(26px,4vw,34px); letter-spacing:.03em }
+.hero p{ margin:0; color:var(--muted); font-size:15px }
+.card{ background:var(--panel); border:1px solid var(--border); border-radius:18px; padding:26px; margin-bottom:28px; box-shadow:0 18px 36px rgba(0,0,0,.3) }
+.card h2{ margin:0 0 10px; font-size:22px; letter-spacing:.02em }
+.card .lead{ margin:0 0 18px; color:var(--muted); font-size:15px }
+.lb-games{ display:flex; gap:10px; flex-wrap:wrap; margin-bottom:18px }
+.lb-game-btn{ appearance:none; border:1px solid rgba(92,212,255,.4); background:rgba(92,212,255,.12); color:var(--txt); border-radius:999px; padding:8px 16px; font-size:14px; font-weight:600; letter-spacing:.3px; cursor:default }
+.lb-filters{ display:flex; flex-wrap:wrap; gap:18px; margin-bottom:18px }
+.lb-filter{ display:flex; flex-direction:column; gap:8px; }
+.lb-filter-label{ font-size:13px; letter-spacing:.25px; text-transform:uppercase; color:var(--muted) }
+.lb-filter-buttons{ display:flex; flex-wrap:wrap; gap:8px; }
+.lb-filter-btn{ appearance:none; border:1px solid rgba(255,255,255,.16); background:rgba(255,255,255,.06); color:var(--txt); border-radius:999px; padding:7px 14px; font-size:13px; letter-spacing:.2px; cursor:pointer; transition:background .2s,border-color .2s,color .2s,box-shadow .2s }
+.lb-filter-btn:hover{ border-color:rgba(92,212,255,.6); box-shadow:0 4px 12px rgba(92,212,255,.25); }
+.lb-filter-btn.is-active{ background:var(--acc); color:#0b1520; border-color:rgba(92,212,255,.85); box-shadow:0 8px 18px rgba(92,212,255,.35); font-weight:700 }
+.lb-vertical{ padding:18px; border:1px solid rgba(255,255,255,.12); border-radius:14px; background:var(--panel2); box-shadow:inset 0 0 0 1px rgba(255,255,255,.04) }
+.lb-vertical h3{ margin:0 0 10px; font-size:16px; letter-spacing:.3px; color:#c6e6ff }
+.lb-status{ font-size:14px; margin:0 0 12px; }
+.lb-status--info{ color:#bcd9ff }
+.lb-status--loading{ color:#9ad0ff }
+.lb-status--success{ color:#8ef59d }
+.lb-status--error{ color:#ff8e8e }
+.lb-status--warning{ color:#ffd27d }
+.lb-list{ list-style:none; padding:0; margin:0 }
+.lb-list li{ display:flex; align-items:baseline; gap:10px; padding:8px 4px; border-top:1px solid rgba(255,255,255,.08); font-size:14px }
+.lb-list li:first-child{ border-top:none }
+.lb-list .lb-rank{ font-weight:700; min-width:3.4em }
+.lb-list .lb-name{ flex:1 1 auto; overflow:hidden; text-overflow:ellipsis; white-space:nowrap }
+.lb-list .lb-score{ color:var(--muted) }
+.lb-list li.lb-row-self{ background:rgba(92,212,255,.10); border-radius:8px; padding:8px 12px }
+.lb-note{ font-size:13px; color:var(--muted); margin:16px 0 0 }
+.lb-note a{ color:var(--acc) }
+footer{ margin-top:46px; padding-top:20px; border-top:1px solid var(--border); color:var(--muted); display:flex; flex-wrap:wrap; gap:12px; justify-content:space-between; font-size:14px }
+footer .links a{ margin-right:16px }
+@media (max-width:720px){
+  .hero{ padding:26px }
+  .card{ padding:22px }
+  .lb-filter-buttons{ gap:6px }
+  .lb-filter-btn{ padding:6px 12px; font-size:12px }
+  .lb-vertical{ padding:16px }
+  .lb-vertical h3{ font-size:15px }
+  .lb-list li{ font-size:13px }
+}
+</style>
+</head><body>
+<header class="site" id="site-header" hidden></header>
+<main>
+  <section class="hero">
+    <h1>ランキング – Irori's Toybox</h1>
+    <p>Lexi Blaster のオンラインランキングを言語モードとレベル別に集約。自分に近い条件のトッププレイヤーをチェックしよう。</p>
+  </section>
+
+  <section class="card" data-game="lexi-blaster">
+    <h2>Lexi Blaster ランキング</h2>
+    <p class="lead">英単語タイピングゲームのハイスコアをモードと言語レベル別に表示します。まずは条件を選んでTOP20を確認！</p>
+
+    <div class="lb-games" role="tablist" aria-label="ゲーム選択">
+      <button type="button" class="lb-game-btn" aria-selected="true">Lexi Blaster</button>
+    </div>
+
+    <div class="lb-filters" aria-label="ランキング条件">
+      <div class="lb-filter" data-filter="mode">
+        <span class="lb-filter-label">モード</span>
+        <div class="lb-filter-buttons" role="group" aria-label="モードの選択">
+          <button type="button" class="lb-filter-btn" data-mode="en_en">EN→EN</button>
+          <button type="button" class="lb-filter-btn" data-mode="jp_en">JP→EN</button>
+        </div>
+      </div>
+      <div class="lb-filter" data-filter="level">
+        <span class="lb-filter-label">レベル</span>
+        <div class="lb-filter-buttons" role="group" aria-label="レベルの選択">
+          <button type="button" class="lb-filter-btn" data-level="A1">A1</button>
+          <button type="button" class="lb-filter-btn" data-level="A2">A2</button>
+          <button type="button" class="lb-filter-btn" data-level="A3">A3</button>
+          <button type="button" class="lb-filter-btn" data-level="B1">B1</button>
+          <button type="button" class="lb-filter-btn" data-level="B2">B2</button>
+          <button type="button" class="lb-filter-btn" data-level="B3">B3</button>
+          <button type="button" class="lb-filter-btn" data-level="C1">C1</button>
+          <button type="button" class="lb-filter-btn" data-level="C2">C2</button>
+          <button type="button" class="lb-filter-btn" data-level="C3">C3</button>
+        </div>
+      </div>
+    </div>
+
+    <div id="lb-embed" class="lb-vertical" hidden>
+      <h3 id="lb-embed-heading">ランキング（A1 / EN→EN）</h3>
+      <div id="lb-embed-status" class="lb-status" hidden></div>
+      <ol id="lb-embed-list" class="lb-list"></ol>
+    </div>
+
+    <p class="lb-note">※ 登録したハンドルネームとスコアは公開されます。不正や誤登録を見つけた場合は <a href="/contact/">お問い合わせフォーム</a> までご連絡ください。</p>
+  </section>
+
+  <footer>
+    <div class="links">
+      <a href="/leaderboard/">ランキング</a>
+      <a href="/lexiblaster/">Lexi Blaster</a>
+      <a href="/changelog/">更新履歴</a>
+      <a href="/contact/">お問い合わせ</a>
+    </div>
+    <div>&copy; <span id="lb-year"></span> Irori</div>
+  </footer>
+</main>
+
+<script>window.LEXI_LEADERBOARD_BASE = 'https://lb.irori-toybox.com';</script>
+<script src="/lexiblaster/leaderboard.js" defer></script>
+<script>
+(function(){
+  const limit = 20;
+  const root = document.getElementById('lb-embed');
+  const statusEl = document.getElementById('lb-embed-status');
+  const listEl = document.getElementById('lb-embed-list');
+  const headingEl = document.getElementById('lb-embed-heading');
+  const modeButtons = Array.from(document.querySelectorAll('[data-mode]'));
+  const levelButtons = Array.from(document.querySelectorAll('[data-level]'));
+
+  const setYear = () => {
+    const el = document.getElementById('lb-year');
+    if (el) el.textContent = new Date().getFullYear();
+  };
+  setYear();
+
+  function ready(){
+    const lb = window.lexiLeaderboard;
+    if (!lb || !root || !statusEl || !listEl || !headingEl) return;
+
+    const defaultCtx = lb.defaultContext;
+    let currentMode = defaultCtx.mode;
+    let currentLevel = defaultCtx.level;
+    let requestSeq = 0;
+
+    function applyQuery(){
+      try {
+        const params = new URLSearchParams(location.search);
+        const ctx = lb.normalizeContext({
+          game: defaultCtx.game,
+          mode: params.get('mode'),
+          level: params.get('level')
+        }, defaultCtx, { strict: false });
+        if (ctx) {
+          currentMode = ctx.mode;
+          currentLevel = ctx.level;
+        }
+      } catch {}
+    }
+
+    function updateHeading(){
+      const label = `${currentLevel} / ${lb.describeMode(currentMode)}`;
+      headingEl.textContent = `ランキング（${label}）`;
+    }
+
+    function updateButtons(){
+      const toggle = (buttons, attr, value) => {
+        for (const btn of buttons) {
+          const key = btn.dataset[attr];
+          const active = key === value;
+          btn.classList.toggle('is-active', active);
+          btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+        }
+      };
+      toggle(modeButtons, 'mode', currentMode);
+      toggle(levelButtons, 'level', currentLevel);
+    }
+
+    function updateQuery(){
+      try {
+        const url = new URL(location.href);
+        url.searchParams.set('mode', currentMode);
+        url.searchParams.set('level', currentLevel);
+        history.replaceState(null, '', url.toString());
+      } catch {}
+    }
+
+    async function load(){
+      const seq = ++requestSeq;
+      root.hidden = false;
+      listEl.innerHTML = '';
+      lb.setStatusElement(statusEl, 'ランキングを読み込み中…', 'loading');
+      const context = { game: defaultCtx.game, mode: currentMode, level: currentLevel };
+      try {
+        const entries = await lb.fetchLeaderboard(limit, context, { allowFallback: false, strict: true });
+        if (seq !== requestSeq) return;
+        lb.renderVerticalList(root, entries, {
+          list: listEl,
+          status: statusEl,
+          limit,
+          emptyMessage: 'まだ登録がありません。最初の挑戦者になろう！',
+          emptyStatusType: 'info'
+        });
+      } catch (err) {
+        console.error('[leaderboard] fetch failed', err);
+        if (seq !== requestSeq) return;
+        lb.renderVerticalList(root, [], {
+          list: listEl,
+          status: statusEl,
+          limit,
+          emptyMessage: 'ランキングを取得できませんでした。',
+          emptyStatusType: 'error'
+        });
+      }
+    }
+
+    function handleModeClick(event){
+      const value = event.currentTarget?.dataset?.mode;
+      if (!value || value === currentMode || !Array.isArray(lb.allowedModes) || !lb.allowedModes.includes(value)) return;
+      currentMode = value;
+      updateHeading();
+      updateButtons();
+      updateQuery();
+      load();
+    }
+
+    function handleLevelClick(event){
+      const value = event.currentTarget?.dataset?.level;
+      if (!value || value === currentLevel || !Array.isArray(lb.allowedLevels) || !lb.allowedLevels.includes(value)) return;
+      currentLevel = value;
+      updateHeading();
+      updateButtons();
+      updateQuery();
+      load();
+    }
+
+    modeButtons.forEach(btn => btn.addEventListener('click', handleModeClick));
+    levelButtons.forEach(btn => btn.addEventListener('click', handleLevelClick));
+
+    window.addEventListener('popstate', () => {
+      applyQuery();
+      updateHeading();
+      updateButtons();
+      load();
+    });
+
+    applyQuery();
+    updateHeading();
+    updateButtons();
+    updateQuery();
+    load();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', ready, { once: true });
+  } else {
+    ready();
+  }
+})();
+</script>
+</body></html>

--- a/leaderboards/index.html
+++ b/leaderboards/index.html
@@ -1,107 +1,17 @@
 <!doctype html><html lang="ja"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Leaderboards | Irori's Toybox</title>
-<meta name="description" content="Irori's Toybox のゲームランキング一覧。Lexi Blaster のトップスコアをチェックしよう。">
-<link rel="stylesheet" href="/assets/site.css">
-<script src="/assets/load-header.js" defer></script>
-<style>
-:root{ --bg:#0b1520; --panel:#121c28; --panel2:#0f1d2a; --txt:#e6f2ff; --muted:#9ab6c9; --acc:#5cd4ff; --border:#203447 }
-*{ box-sizing:border-box }
-body{ margin:0; background:var(--bg); color:var(--txt); font:16px/1.7 system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif; }
-a{ color:var(--acc); text-decoration:none } a:hover{ text-decoration:underline }
-main{ width:min(960px,92vw); margin:28px auto 80px }
-.hero{ background:linear-gradient(180deg,rgba(18,28,40,.92),rgba(12,22,34,.92)); border:1px solid var(--border); border-radius:18px; padding:28px; margin-bottom:24px; box-shadow:0 18px 40px rgba(0,0,0,.32) }
-.hero h1{ margin:0 0 10px; font-size:clamp(24px,4vw,32px); letter-spacing:.03em }
-.hero p{ margin:0; color:var(--muted) }
-.card{ background:var(--panel); border:1px solid var(--border); border-radius:16px; padding:20px; margin-bottom:24px; box-shadow:0 14px 36px rgba(0,0,0,.28) }
-.card h2{ margin:0 0 12px; font-size:22px; letter-spacing:.02em }
-.card .lead{ margin:0 0 14px; color:var(--muted) }
-.lb-vertical{ padding:14px; border:1px solid rgba(255,255,255,.08); border-radius:12px; background:var(--panel2) }
-.lb-status{ font-size:14px; margin:0 0 10px; }
-.lb-status--info{ color:#bcd9ff }
-.lb-status--loading{ color:#9ad0ff }
-.lb-status--success{ color:#8ef59d }
-.lb-status--error{ color:#ff8e8e }
-.lb-status--warning{ color:#ffd27d }
-.lb-list{ list-style:none; padding:0; margin:0 }
-.lb-list li{ display:flex; align-items:baseline; gap:10px; padding:8px 4px; border-top:1px solid rgba(255,255,255,.08); font-size:14px }
-.lb-list li:first-child{ border-top:none }
-.lb-rank{ font-weight:700; min-width:3.4em }
-.lb-name{ flex:1 1 auto; overflow:hidden; text-overflow:ellipsis; white-space:nowrap }
-.lb-score{ color:var(--muted) }
-.lb-list li.lb-row-self{ background:rgba(92,212,255,.10); border-radius:6px; padding:8px 12px }
-.lb-row-self{ background:rgba(92,212,255,.10); border-radius:6px }
-footer{ margin-top:40px; padding-top:18px; border-top:1px solid var(--border); color:var(--muted); display:flex; flex-wrap:wrap; gap:12px; justify-content:space-between }
-footer .links a{ margin-right:14px }
-@media (max-width:640px){
-  .hero{ padding:22px }
-  .card{ padding:18px }
-  .lb-list li{ font-size:13px }
-}
-</style>
-</head><body>
-<header class="site" id="site-header" hidden></header>
-<main>
-  <section class="hero">
-    <h1>Leaderboards</h1>
-    <p>Irori's Toybox で公開中のゲームランキングをまとめました。まずは Lexi Blaster のスコアをチェック！</p>
-  </section>
-
-  <section class="card" data-game="lexi-blaster">
-    <h2>Lexi Blaster — TOP 20</h2>
-    <p class="lead">英単語タイピングゲームの最新ランキング。あなたのハイスコアもここに刻もう。</p>
-    <div id="lb-embed" class="lb-vertical" hidden>
-      <div id="lb-embed-status" class="lb-status" hidden></div>
-      <ol id="lb-embed-list" class="lb-list"></ol>
-    </div>
-  </section>
-
-  <footer>
-    <div class="links">
-      <a href="/leaderboards/">ランキング</a>
-      <a href="/lexiblaster/">Lexi Blaster</a>
-      <a href="/changelog/">更新履歴</a>
-      <a href="/contact/">お問い合わせ</a>
-    </div>
-    <div>&copy; <span id="lb-year"></span> Irori</div>
-  </footer>
-</main>
-
-<script>window.LEXI_LEADERBOARD_BASE = 'https://lb.irori-toybox.com';</script>
-<script src="/lexiblaster/leaderboard.js" defer></script>
+<title>ランキングは移動しました – Irori's Toybox</title>
+<meta http-equiv="refresh" content="0; url=/leaderboard/">
+<link rel="canonical" href="https://irori-toybox.com/leaderboard/">
+<meta name="robots" content="noindex">
 <script>
-(function(){
-  const limit = 20;
-  const root = document.getElementById('lb-embed');
-  const statusEl = document.getElementById('lb-embed-status');
-  const listEl = document.getElementById('lb-embed-list');
-  const setYear = () => { const y = document.getElementById('lb-year'); if (y) y.textContent = new Date().getFullYear(); };
-  setYear();
-  const boot = async () => {
-    if (!window.lexiLeaderboard || !root || !statusEl || !listEl) return;
-    const { fetchLeaderboard, renderVerticalList, setStatusElement } = window.lexiLeaderboard;
+  (function(){
     try {
-      setStatusElement(statusEl, '読み込み中…', 'loading');
-      root.hidden = false;
-      listEl.innerHTML = '';
-      const entries = await fetchLeaderboard(limit);
-      renderVerticalList(root, entries, { list: listEl, status: statusEl, limit });
-    } catch (err) {
-      console.error('[leaderboards] fetch failed', err);
-      renderVerticalList(root, [], {
-        list: listEl,
-        status: statusEl,
-        limit,
-        emptyMessage: '取得に失敗しました。時間をおいて再度お試しください。',
-        emptyStatusType: 'error'
-      });
-    }
-  };
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', boot, { once: true });
-  } else {
-    boot();
-  }
-})();
+      var dest = '/leaderboard/' + (location.search || '') + (location.hash || '');
+      location.replace(dest);
+    } catch {}
+  })();
 </script>
+</head><body>
+<p>ランキングページは <a href="/leaderboard/">/leaderboard/</a> に移動しました。自動的に遷移しない場合はリンクをクリックしてください。</p>
 </body></html>

--- a/lexiblaster/score.js
+++ b/lexiblaster/score.js
@@ -161,7 +161,7 @@
       .lexi-miss code{font-weight:700;}
 
       .lexi-leaderboard{margin-top:20px;padding-top:16px;border-top:1px solid rgba(255,255,255,.06);}
-      .lexi-leaderboard h3{margin:0 0 8px;font-size:16px;}
+      .lexi-leaderboard h3{margin:0 0 8px;font-size:16px;letter-spacing:.3px;}
       .lexi-leaderboard label{display:block;font-size:12px;font-weight:600;margin-bottom:6px;letter-spacing:.2px;}
       .lexi-leaderboard-form{margin-bottom:14px;}
       .lexi-leaderboard-inputs{display:flex;gap:8px;flex-wrap:wrap;align-items:center;}
@@ -228,7 +228,7 @@
           </div>
 
           <div class="lexi-leaderboard" id="lb-leaderboard" hidden>
-            <h3>オンラインランキング</h3>
+            <h3 id="lb-leaderboard-heading">ランキング（A1 / EN→EN）</h3>
             <div class="lb-layout">
               <div class="lb-primary">
                 <p class="lb-status" id="lb-leaderboard-status" aria-live="polite">ハイスコアを登録してランキングに参加しよう！</p>
@@ -244,9 +244,10 @@
                   <tbody id="lb-leaderboard-body"></tbody>
                 </table>
                 <p class="lexi-note" id="lb-leaderboard-empty" hidden>まだ登録がありません。最初の挑戦者になろう！</p>
+                <p class="lexi-note" id="lb-leaderboard-note">※ 登録したハンドルネームとスコアはランキングページに公開されます。</p>
               </div>
               <aside id="lb-vertical" class="lb-vertical" hidden>
-                <p class="lb-vertical-heading">TOP 20</p>
+                <p class="lb-vertical-heading" id="lb-vertical-heading">TOP 20（A1 / EN→EN）</p>
                 <div id="lb-vertical-status" class="lb-status" hidden></div>
                 <ol id="lb-vertical-list" class="lb-list"></ol>
               </aside>

--- a/partials/header.html
+++ b/partials/header.html
@@ -3,7 +3,7 @@
   <nav>
     <a class="link" data-path="/"               href="/">Home</a>
     <a class="link" data-path="/lexiblaster/"   href="/lexiblaster/">Lexi Blaster</a>
-    <a class="link" data-path="/leaderboards/"  href="/leaderboards/">ランキング</a>
+    <a class="link" data-path="/leaderboard/"   href="/leaderboard/">ランキング</a>
     <a class="link" data-path="/changelog/"     href="/changelog/">更新履歴</a>
     <a class="link" data-path="/privacy/"       href="/privacy/">プライバシー</a>
     <a class="link" data-path="/cookie-policy/" href="/cookie-policy/">クッキー</a>

--- a/worker/leaderboard.js
+++ b/worker/leaderboard.js
@@ -1,0 +1,300 @@
+const DEFAULT_GAME = 'lexi-blaster';
+const ALLOWED_GAMES = [DEFAULT_GAME];
+const ALLOWED_MODES = ['en_en', 'jp_en', 'en_jp'];
+const ALLOWED_LEVELS = ['A1','A2','A3','B1','B2','B3','C1','C2','C3'];
+
+const MAX_NAME_LENGTH = 12;
+const MAX_SCORE = 999999;
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+const STORAGE_LIMIT = 5000;
+const RATE_LIMIT_MAX = 3;
+const RATE_LIMIT_WINDOW = 60; // seconds
+
+export default {
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+    const pathname = normalizePath(url.pathname);
+
+    if (request.method === 'OPTIONS') {
+      return handleOptions(request, env);
+    }
+
+    if (pathname === '/top' && request.method === 'GET') {
+      return handleGetTop(request, env);
+    }
+    if (pathname === '/score' && request.method === 'POST') {
+      return handlePostScore(request, env, ctx);
+    }
+
+    return jsonResponse({ error: 'NOT_FOUND' }, 404, request, env);
+  }
+};
+
+function normalizePath(pathname){
+  if (!pathname) return '/';
+  const trimmed = pathname.replace(/\/+$/g, '') || '/';
+  return trimmed;
+}
+
+async function handleGetTop(request, env){
+  const url = new URL(request.url);
+  const context = normalizeContext({
+    game: url.searchParams.get('game'),
+    mode: url.searchParams.get('mode'),
+    level: url.searchParams.get('level')
+  }, { strict: true });
+  if (!context.ok) {
+    return jsonResponse({ error: context.error }, 400, request, env);
+  }
+
+  const rawLimit = Number(url.searchParams.get('limit'));
+  const limit = clampLimit(rawLimit);
+
+  try {
+    const kv = requireKv(env.LEADERBOARD, 'LEADERBOARD');
+    const key = buildKey(context.value);
+    const records = await readEntries(kv, key);
+    const sorted = sortEntries(records);
+    const top = sorted.slice(0, limit).map((entry, idx) => ({
+      name: entry.name,
+      score: entry.score,
+      timestamp: entry.timestamp,
+      rank: idx + 1
+    }));
+    return jsonResponse({ results: top }, 200, request, env, { 'Cache-Control': 'no-store' });
+  } catch (err) {
+    console.error('[leaderboard] GET /top failed', err);
+    return jsonResponse({ error: 'INTERNAL_ERROR' }, 500, request, env);
+  }
+}
+
+async function handlePostScore(request, env, ctx){
+  let payload;
+  try {
+    payload = await request.json();
+  } catch {
+    return jsonResponse({ error: 'INVALID_JSON' }, 400, request, env);
+  }
+
+  const context = normalizeContext({
+    game: payload?.game,
+    mode: payload?.mode,
+    level: payload?.level
+  }, { strict: true });
+  if (!context.ok) {
+    return jsonResponse({ error: context.error }, 400, request, env);
+  }
+
+  const name = sanitizeName(payload?.name);
+  const score = clampScore(payload?.score);
+  if (!name) {
+    return jsonResponse({ error: 'NAME_REQUIRED' }, 400, request, env);
+  }
+  if (!(score > 0)) {
+    return jsonResponse({ error: 'SCORE_REQUIRED' }, 400, request, env);
+  }
+
+  try {
+    const kv = requireKv(env.LEADERBOARD, 'LEADERBOARD');
+    const rateKv = env.LEADERBOARD_RATELIMIT;
+    const ip = request.headers.get('cf-connecting-ip') || request.headers.get('x-forwarded-for') || request.cf?.connectingIP || 'unknown';
+    const rateKey = buildRateLimitKey(context.value, ip);
+
+    if (rateKv) {
+      const allowed = await checkRateLimit(rateKv, rateKey);
+      if (!allowed) {
+        return jsonResponse({ error: 'RATE_LIMITED' }, 429, request, env, { 'Retry-After': String(RATE_LIMIT_WINDOW) });
+      }
+    }
+
+    const entry = {
+      id: crypto.randomUUID(),
+      name,
+      score,
+      timestamp: Date.now()
+    };
+
+    const key = buildKey(context.value);
+    const existing = await readEntries(kv, key);
+    const updated = appendEntry(existing, entry);
+    const sorted = sortEntries(updated);
+    const rankIndex = sorted.findIndex(item => item.id === entry.id);
+    const rank = rankIndex >= 0 ? rankIndex + 1 : null;
+
+    const storePromise = kv.put(key, JSON.stringify(updated));
+    ctx.waitUntil(storePromise);
+
+    return jsonResponse({ ok: true, rank, entry: { name: entry.name, score: entry.score, timestamp: entry.timestamp } }, 200, request, env);
+  } catch (err) {
+    console.error('[leaderboard] POST /score failed', err);
+    return jsonResponse({ error: 'INTERNAL_ERROR' }, 500, request, env);
+  }
+}
+
+function sanitizeName(value){
+  if (typeof value !== 'string') return '';
+  let cleaned = value.replace(/[\u0000-\u001F\u007F]/g, '').trim();
+  cleaned = cleaned.replace(/\s+/g, ' ');
+  if (cleaned.length > MAX_NAME_LENGTH) cleaned = cleaned.slice(0, MAX_NAME_LENGTH);
+  return cleaned;
+}
+
+function clampScore(value){
+  const num = Math.floor(Number(value) || 0);
+  if (!Number.isFinite(num) || num < 0) return 0;
+  return Math.min(num, MAX_SCORE);
+}
+
+function clampLimit(value){
+  if (!Number.isFinite(value) || value <= 0) return DEFAULT_LIMIT;
+  return Math.max(1, Math.min(MAX_LIMIT, Math.floor(value)));
+}
+
+function normalizeContext(meta, { strict = false } = {}){
+  const game = sanitizeGame(meta?.game) || (strict ? '' : DEFAULT_GAME);
+  const mode = sanitizeMode(meta?.mode);
+  const level = sanitizeLevel(meta?.level);
+
+  if (!game) return { ok: false, error: 'INVALID_GAME' };
+  if (!mode) return { ok: false, error: 'INVALID_MODE' };
+  if (!level) return { ok: false, error: 'INVALID_LEVEL' };
+
+  return { ok: true, value: { game, mode, level } };
+}
+
+function sanitizeGame(value){
+  if (typeof value !== 'string') return '';
+  const normalized = value.trim().toLowerCase();
+  return ALLOWED_GAMES.includes(normalized) ? normalized : '';
+}
+
+function sanitizeMode(value){
+  if (typeof value !== 'string') return '';
+  const normalized = value.trim().toLowerCase();
+  return ALLOWED_MODES.includes(normalized) ? normalized : '';
+}
+
+function sanitizeLevel(value){
+  if (typeof value !== 'string') return '';
+  const normalized = value.trim().toUpperCase();
+  return ALLOWED_LEVELS.includes(normalized) ? normalized : '';
+}
+
+function buildKey(context){
+  return `lb:v1:${context.game}:${context.mode}:${context.level}`;
+}
+
+function appendEntry(list, entry){
+  const next = Array.isArray(list) ? [...list, entry] : [entry];
+  if (next.length > STORAGE_LIMIT) {
+    next.splice(0, next.length - STORAGE_LIMIT);
+  }
+  return next;
+}
+
+function sortEntries(list){
+  const entries = Array.isArray(list) ? [...list] : [];
+  entries.sort((a, b) => {
+    const sa = Number.isFinite(a?.score) ? a.score : 0;
+    const sb = Number.isFinite(b?.score) ? b.score : 0;
+    if (sb !== sa) return sb - sa;
+    const ta = Number.isFinite(a?.timestamp) ? a.timestamp : Number.MAX_SAFE_INTEGER;
+    const tb = Number.isFinite(b?.timestamp) ? b.timestamp : Number.MAX_SAFE_INTEGER;
+    return ta - tb;
+  });
+  return entries;
+}
+
+async function readEntries(kv, key){
+  try {
+    const raw = await kv.get(key);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.map(item => ({
+      id: item?.id || crypto.randomUUID(),
+      name: sanitizeName(item?.name),
+      score: clampScore(item?.score),
+      timestamp: Number.isFinite(item?.timestamp) ? item.timestamp : null
+    }));
+  } catch {
+    return [];
+  }
+}
+
+function requireKv(kv, name){
+  if (!kv || typeof kv.get !== 'function' || typeof kv.put !== 'function') {
+    throw new Error(`${name}_KV_NOT_CONFIGURED`);
+  }
+  return kv;
+}
+
+function buildRateLimitKey(context, ip){
+  return `rl:v1:${context.game}:${context.mode}:${context.level}:${ip}`;
+}
+
+async function checkRateLimit(kv, key){
+  const bucket = await kv.get(key);
+  const count = bucket ? Number(bucket) : 0;
+  if (Number.isFinite(count) && count >= RATE_LIMIT_MAX) {
+    return false;
+  }
+  const nextCount = Number.isFinite(count) && count >= 0 ? count + 1 : 1;
+  await kv.put(key, String(nextCount), { expirationTtl: RATE_LIMIT_WINDOW });
+  return true;
+}
+
+function parseAllowedOrigins(env){
+  if (!env || typeof env.ALLOWED_ORIGINS !== 'string') return null;
+  const list = env.ALLOWED_ORIGINS.split(',').map(s => s.trim()).filter(Boolean);
+  return list.length ? list : null;
+}
+
+function resolveCors(request, env){
+  const originHeader = request.headers.get('Origin');
+  if (!originHeader) {
+    return { allowed: true, headers: {} };
+  }
+  const allowedList = parseAllowedOrigins(env);
+  if (!allowedList) {
+    return { allowed: true, headers: { 'Access-Control-Allow-Origin': originHeader, 'Vary': 'Origin' } };
+  }
+  if (allowedList.includes('*')) {
+    return { allowed: true, headers: { 'Access-Control-Allow-Origin': '*', 'Vary': 'Origin' } };
+  }
+  if (allowedList.includes(originHeader)) {
+    return { allowed: true, headers: { 'Access-Control-Allow-Origin': originHeader, 'Vary': 'Origin' } };
+  }
+  return { allowed: false, headers: {} };
+}
+
+function handleOptions(request, env){
+  const cors = resolveCors(request, env);
+  if (!cors.allowed) {
+    return new Response(null, { status: 403 });
+  }
+  const headers = {
+    ...cors.headers,
+    'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Max-Age': '86400'
+  };
+  return new Response(null, { status: 204, headers });
+}
+
+function jsonResponse(body, status, request, env, extraHeaders = {}){
+  const cors = resolveCors(request, env);
+  if (!cors.allowed) {
+    return new Response(JSON.stringify({ error: 'ORIGIN_NOT_ALLOWED' }), { status: 403, headers: { 'Content-Type': 'application/json' } });
+  }
+  const headers = {
+    'Content-Type': 'application/json',
+    ...cors.headers,
+    ...extraHeaders
+  };
+  if (!headers['Cache-Control']) {
+    headers['Cache-Control'] = 'no-store';
+  }
+  return new Response(JSON.stringify(body), { status, headers });
+}


### PR DESCRIPTION
## Summary
- extend the Lexi Blaster leaderboard client to include game/mode/level context, render the new level/mode headings, and adopt the Top20 vertical layout
- refresh the score overlay markup and nav links, add the new /leaderboard hub with filters, and leave a redirect at /leaderboards
- add a Cloudflare Worker script that persists scores in KV using the expanded parameters and enforces validation and rate limiting

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d140e64d04832ba32a860b1eb340a8