### PR TITLE
Improve SEO metadata for Lexi Blaster pages

### DIFF
--- a/ads.txt
+++ b/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-6056438145584303, DIRECT, f08c47fec0942fa0

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
   <meta charset="utf-8" />
-  <title>Irori's Toybox — 小さな作品たちの置き場</title>
+  <title>Irori's Toybox｜英単語タイピングゲーム「Lexi Blaster」など小さな作品たちの置き場</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <meta name="description" content="個人開発のミニゲームや学習ツールを置いていく実験箱。おすすめは英単語タイピングゲーム『Lexi Blaster』。" />
   <link rel="canonical" href="https://irori-toybox.com/">
@@ -10,7 +10,7 @@
 
   <!-- OG/Twitter -->
   <meta property="og:title" content="Irori's Toybox" />
-  <meta property="og:description" content="個人開発のミニゲームや学習ツールの置き場。英単語ゲーム『Lexi Blaster』公開中。" />
+  <meta property="og:description" content="個人開発のミニゲームや学習ツールの置き場。英単語タイピングゲーム『Lexi Blaster』公開中。" />
   <meta property="og:url" content="https://irori-toybox.com/" />
   <meta property="og:image" content="https://irori-toybox.com/ogp.png" />
   <meta property="og:type" content="website" />
@@ -49,6 +49,28 @@
     }
     nav a{ margin-left:14px; color:var(--muted); }
     nav a:hover{ color:var(--txt); }
+
+    .hero-lb{
+      margin: 30px 0 12px;
+      padding: 26px;
+      border:1px solid var(--border);
+      border-radius:16px;
+      background: linear-gradient(180deg, rgba(18,28,40,.9), rgba(15,29,42,.9));
+      box-shadow: 0 20px 50px rgba(0,0,0,.35);
+    }
+    .hero-lb h1{ margin:0 0 10px; font-size: clamp(26px, 5vw, 34px); letter-spacing:.04em; }
+    .hero-lb p{ margin:0; color:var(--muted); font-size:15px; }
+    .hero-lb a{ color:var(--acc); font-weight:600; }
+
+    .top-links{
+      list-style:none;
+      padding:0;
+      margin:16px 0 32px;
+      display:flex;
+      flex-wrap:wrap;
+      gap:12px;
+    }
+    .top-links a{ color:var(--acc); font-weight:600; }
 
     .hero{
       margin: 6px 0 24px;
@@ -138,8 +160,18 @@
 </head>
 <body>
   <header class="site" id="site-header" hidden></header>
+    <section class="hero-lb">
+      <h1>Irori's Toybox</h1>
+      <p>ブラウザで気軽に遊べる小さなゲームを公開中。おすすめは「<a href="/lexiblaster/">英単語タイピングゲーム『Lexi Blaster』</a>」。無料で遊べて語彙力アップ、<a href="/leaderboard/">ランキング</a>にも対応！</p>
+    </section>
+
+    <ul class="top-links">
+      <li><a href="/lexiblaster/">英単語タイピングゲーム｜Lexi Blaster</a></li>
+      <li><a href="/leaderboard/">Lexi Blaster ランキング（モード・レベル別）</a></li>
+    </ul>
+
     <section class="hero">
-      <h1>小さな作品たちの置き場へようこそ。</h1>
+      <h2>小さな作品たちの置き場へようこそ。</h2>
       <div class="cta-row">
         <a class="btn primary" href="/lexiblaster/">
           ▶ 今すぐプレイ

--- a/leaderboard/index.html
+++ b/leaderboard/index.html
@@ -1,12 +1,19 @@
 <!doctype html><html lang="ja"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>ランキング – Irori's Toybox</title>
-<meta name="description" content="英単語タイピングゲーム Lexi Blaster のオンラインランキング。モードと言語レベル別のトップスコアをチェックしよう。">
+<title>Lexi Blaster ランキング｜英単語タイピングゲームのスコア集計（モード・レベル別TOP20）</title>
+<meta name="description" content="英単語タイピングゲーム『Lexi Blaster』のオンラインランキング。EN→EN / JP→EN などの言語モード・レベル別にTOP20を表示。全国のプレイヤーとスコアを競おう。">
 <link rel="canonical" href="https://irori-toybox.com/leaderboard/">
-<meta property="og:title" content="ランキング – Irori's Toybox">
-<meta property="og:description" content="英単語タイピングゲーム Lexi Blaster のオンラインランキング。モードと言語レベル別のトップスコアをチェックしよう。">
+<meta property="og:title" content="Lexi Blaster ランキング｜英単語タイピングゲーム">
+<meta property="og:description" content="無料で遊べる英単語タイピングゲームのオンラインランキング。モード・レベル別TOP20をチェックしよう。">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://irori-toybox.com/leaderboard/">
+<meta property="og:image" content="https://irori-toybox.com/lexiblaster/social/lexi-blaster-og.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Lexi Blaster ランキング｜英単語タイピングゲーム">
+<meta name="twitter:description" content="英単語タイピングゲーム『Lexi Blaster』のランキングをモード・レベル別に掲載。">
+<meta name="twitter:image" content="https://irori-toybox.com/lexiblaster/social/lexi-blaster-og.png">
 <link rel="stylesheet" href="/assets/site.css">
 <script src="/assets/load-header.js" defer></script>
 <style>
@@ -17,7 +24,10 @@ a{ color:var(--acc); text-decoration:none } a:hover{ text-decoration:underline }
 main{ width:min(980px,92vw); margin:28px auto 84px }
 .hero{ background:linear-gradient(180deg,rgba(18,28,40,.92),rgba(12,22,34,.92)); border:1px solid var(--border); border-radius:18px; padding:32px; margin-bottom:26px; box-shadow:0 18px 40px rgba(0,0,0,.32) }
 .hero h1{ margin:0 0 12px; font-size:clamp(26px,4vw,34px); letter-spacing:.03em }
-.hero p{ margin:0; color:var(--muted); font-size:15px }
+.hero h2{ margin:0 0 14px; color:var(--muted); font-size:15px; font-weight:600; letter-spacing:.02em }
+.lb-internal-links{ font-size:14px; color:var(--muted); }
+.lb-internal-links a{ color:var(--acc); }
+.lb-internal-links a:hover{ text-decoration:underline }
 .card{ background:var(--panel); border:1px solid var(--border); border-radius:18px; padding:26px; margin-bottom:28px; box-shadow:0 18px 36px rgba(0,0,0,.3) }
 .card h2{ margin:0 0 10px; font-size:22px; letter-spacing:.02em }
 .card .lead{ margin:0 0 18px; color:var(--muted); font-size:15px }
@@ -59,12 +69,25 @@ footer .links a{ margin-right:16px }
   .lb-list li{ font-size:13px }
 }
 </style>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": "Lexi Blaster ランキング",
+  "description": "英単語タイピングゲームのオンラインランキング（モード・レベル別）。",
+  "url": "https://irori-toybox.com/leaderboard/"
+}
+</script>
 </head><body>
 <header class="site" id="site-header" hidden></header>
 <main>
   <section class="hero">
-    <h1>ランキング – Irori's Toybox</h1>
-    <p>Lexi Blaster のオンラインランキングを言語モードとレベル別に集約。自分に近い条件のトッププレイヤーをチェックしよう。</p>
+    <h1>Lexi Blaster ランキング</h1>
+    <h2>英単語タイピングゲームのスコアをモード・レベル別に掲載（TOP20）</h2>
+    <nav class="lb-internal-links">
+      <a href="/lexiblaster/">英単語タイピングゲーム「Lexi Blaster」で遊ぶ</a> /
+      <a href="/">Irori's Toybox トップへ</a>
+    </nav>
   </section>
 
   <section class="card" data-game="lexi-blaster">

--- a/lexiblaster/index.html
+++ b/lexiblaster/index.html
@@ -2,19 +2,25 @@
 <html lang="ja">
 <head>
   <meta charset="UTF-8" />
-  <title>Lexi Blaster</title>
+  <title>英単語タイピングゲーム｜Lexi Blaster - 無料で遊べる英語学習ブラウザゲーム</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="英単語タイピングゲーム『Lexi Blaster』は、無料で遊べる英語学習ブラウザゲーム。英単語をタイピングして敵を撃ち抜きながら語彙力アップ！ランキング機能付きで全国のプレイヤーと競える。" />
+  <link rel="canonical" href="https://irori-toybox.com/lexiblaster/" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Lexi Blaster" />
-  <meta property="og:description" content="英単語で敵を撃ち抜け！ハイスコアを目指せ。" />
-  <meta property="og:image" content="https://irori-toybox.com/lexiblaster/social/lexi-blaster-og.png" />
-  <meta property="og:url" content="https://irori-toybox.com/lexiblaster/" />
+  <meta property="og:title" content="英単語タイピングゲーム｜Lexi Blaster" />
+  <meta property="og:description" content="無料で遊べる英語学習ブラウザゲーム。英単語をタイピングして敵を撃ち抜け！ランキング対応。" />
   <meta property="og:type" content="website" />
-  <meta property="og:site_name" content="Lexi Blaster" />
+  <meta property="og:url" content="https://irori-toybox.com/lexiblaster/" />
+  <meta property="og:image" content="https://irori-toybox.com/lexiblaster/social/lexi-blaster-og.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
-  <meta property="og:image:type" content="image/png" />
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="英単語タイピングゲーム｜Lexi Blaster" />
+  <meta name="twitter:description" content="無料で遊べる英語学習ブラウザゲーム。ランキング対応。" />
+  <meta name="twitter:image" content="https://irori-toybox.com/lexiblaster/social/lexi-blaster-og.png" />
 
   <!-- Favicon（404対策：/lexiblaster/favicon.ico を用意した場合はこちらを使う） -->
   <link rel="icon" href="/lexiblaster/favicon.ico" />
@@ -29,11 +35,35 @@
   <!-- ゲーム固有CSS -->
   <link rel="stylesheet" href="style.css" />
 
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "VideoGame",
+    "name": "Lexi Blaster",
+    "url": "https://irori-toybox.com/lexiblaster/",
+    "description": "英単語タイピングゲーム『Lexi Blaster』は、無料で遊べる英語学習ブラウザゲーム。英単語をタイピングして敵を撃ち抜きながら語彙力アップ！ランキング機能付きで全国のプレイヤーと競える。",
+    "genre": ["Educational", "Typing", "English Learning"],
+    "operatingSystem": "Web Browser",
+    "applicationCategory": "Game",
+    "image": "https://irori-toybox.com/lexiblaster/social/lexi-blaster-og.png",
+    "publisher": {
+      "@type": "Organization",
+      "name": "Irori"
+    }
+  }
+  </script>
 
 </head>
 <body>
   <!-- 共通ヘッダー。load-header.js が中身を差し込む -->
   <header class="site" id="site-header" hidden></header>
+
+  <h1>英単語タイピングゲーム「Lexi Blaster」</h1>
+  <h2>無料で遊べる英語学習・タイピング練習ブラウザゲーム</h2>
+  <nav class="lb-internal-links">
+    <a href="/leaderboard/">Lexi Blaster ランキング（言語モード・レベル別）</a> /
+    <a href="/">Irori's Toybox トップへ</a>
+  </nav>
 
   <div id="wrap">
     <canvas id="gameCanvas" width="800" height="720"></canvas>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://irori-toybox.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://irori-toybox.com/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://irori-toybox.com/lexiblaster/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://irori-toybox.com/leaderboard/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- update Lexi Blaster, leaderboard, and homepage metadata with SEO-friendly titles, descriptions, and OG/Twitter tags
- add structured data, hero copy, and internal links to emphasize the 英単語タイピングゲーム content
- publish supporting robots.txt, sitemap.xml, and ads.txt files for crawlability and ad verification

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68dde0965984832bb43fac0e4b1d95d3