### PR TITLE
Add terms page and expand Lexi Blaster content

### DIFF
--- a/assets/load-header.js
+++ b/assets/load-header.js
@@ -15,7 +15,11 @@
         <a class="brand" href="/"><div class="logo">IT</div><strong>Irori's Toybox</strong></a>
         <nav>
           <a class="link" href="/">Home</a>
+          <a class="link" href="/lexiblaster/">Lexi Blaster</a>
           <a class="link" href="/leaderboard/">ランキング</a>
+          <a class="link" href="/terms/">Terms</a>
+          <a class="link" href="/privacy/">プライバシー</a>
+          <a class="link" href="/contact/">お問い合わせ</a>
         </nav>
       </div>`;
     return;

--- a/assets/owner_icon.svg
+++ b/assets/owner_icon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4c8bf5" />
+      <stop offset="100%" stop-color="#223a72" />
+    </linearGradient>
+  </defs>
+  <rect width="96" height="96" rx="48" fill="url(#bg)" />
+  <circle cx="48" cy="36" r="18" fill="#fff" opacity="0.9" />
+  <path d="M24 78c4-18 16-28 24-28s20 10 24 28" fill="#fff" opacity="0.9" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -16,6 +16,9 @@
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
 
+  <!-- AdSense（サイト審査用タグ：そのままでOK） -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6056438145584303" crossorigin="anonymous"></script>
+
   <link rel="stylesheet" href="/assets/site.css">
   <script src="/assets/load-header.js" defer></script>
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <title>Irori's Toybox｜英単語タイピングゲーム「Lexi Blaster」など小さな作品たちの置き場</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <meta name="description" content="個人開発のミニゲームや学習ツールを置いていく実験箱。おすすめは英単語タイピングゲーム『Lexi Blaster』。" />
+  <meta name="description" content="英単語約5,000語を収録。完全無料・登録不要のタイピング学習ゲーム『Lexi Blaster』。CEFR A1–C1対応、ランキング機能つき。" />
   <link rel="canonical" href="https://irori-toybox.com/">
   <meta name="theme-color" content="#0b1520" />
 
@@ -15,9 +15,6 @@
   <meta property="og:image" content="https://irori-toybox.com/ogp.png" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-
-  <!-- AdSense（サイト審査用タグ：そのままでOK） -->
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6056438145584303" crossorigin="anonymous"></script>
 
   <link rel="stylesheet" href="/assets/site.css">
   <script src="/assets/load-header.js" defer></script>
@@ -180,6 +177,16 @@
         <a class="btn" href="/changelog/">📝 更新履歴を見る</a>
         <a class="btn" href="/leaderboard/">🏆 ランキングを見る</a>
       </div>
+    </section>
+
+    <section id="about-lexiblaster" style="margin-top:32px">
+      <h2>英単語を楽しく覚える新感覚タイピングゲーム</h2>
+      <p>
+        Lexi Blaster は、AI × ゲームで語彙学習を加速する英語学習アプリです。
+        CEFR A1〜C1 を中心に <strong>約5,000語</strong>を収録。想起 → 綴り → 即時フィードバックで記憶定着を促します。
+      </p>
+      <p><strong>完全無料・登録不要</strong>で、どなたでも今すぐ試せます。</p>
+      <p><a href="/lexiblaster/">▶ Lexi Blaster をプレイ</a></p>
     </section>
 
     <div class="grid">

--- a/lexiblaster/index.html
+++ b/lexiblaster/index.html
@@ -4,12 +4,12 @@
   <meta charset="UTF-8" />
   <title>英単語タイピングゲーム｜Lexi Blaster - 無料で遊べる英語学習ブラウザゲーム</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="description" content="英単語タイピングゲーム『Lexi Blaster』は、無料で遊べる英語学習ブラウザゲーム。英単語をタイピングして敵を撃ち抜きながら語彙力アップ！ランキング機能付きで全国のプレイヤーと競える。" />
+  <meta name="description" content="英単語約5,000語を収録する英単語タイピングゲーム『Lexi Blaster』。完全無料・登録不要で遊べる英語学習ブラウザゲーム。ランキング機能付きで全国のプレイヤーと競える。" />
   <link rel="canonical" href="https://irori-toybox.com/lexiblaster/" />
 
   <!-- Open Graph -->
   <meta property="og:title" content="英単語タイピングゲーム｜Lexi Blaster" />
-  <meta property="og:description" content="無料で遊べる英語学習ブラウザゲーム。英単語をタイピングして敵を撃ち抜け！ランキング対応。" />
+  <meta property="og:description" content="約5,000語を収録した無料の英単語タイピングゲーム。英単語をタイピングして敵を撃ち抜け！ランキング対応。" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://irori-toybox.com/lexiblaster/" />
   <meta property="og:image" content="https://irori-toybox.com/lexiblaster/social/lexi-blaster-og.png" />
@@ -19,7 +19,7 @@
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="英単語タイピングゲーム｜Lexi Blaster" />
-  <meta name="twitter:description" content="無料で遊べる英語学習ブラウザゲーム。ランキング対応。" />
+  <meta name="twitter:description" content="約5,000語を収録した無料の英単語タイピングゲーム。ランキング対応。" />
   <meta name="twitter:image" content="https://irori-toybox.com/lexiblaster/social/lexi-blaster-og.png" />
 
   <!-- Favicon（404対策：/lexiblaster/favicon.ico を用意した場合はこちらを使う） -->
@@ -41,7 +41,7 @@
     "@type": "VideoGame",
     "name": "Lexi Blaster",
     "url": "https://irori-toybox.com/lexiblaster/",
-    "description": "英単語タイピングゲーム『Lexi Blaster』は、無料で遊べる英語学習ブラウザゲーム。英単語をタイピングして敵を撃ち抜きながら語彙力アップ！ランキング機能付きで全国のプレイヤーと競える。",
+    "description": "英単語約5,000語を収録する無料の英語学習タイピングゲーム。英単語をタイピングして敵を撃ち抜きながら語彙力アップ！ランキング機能付きで全国のプレイヤーと競える。",
     "genre": ["Educational", "Typing", "English Learning"],
     "operatingSystem": "Web Browser",
     "applicationCategory": "Game",
@@ -67,6 +67,39 @@
 
   <div id="wrap">
     <canvas id="gameCanvas" width="800" height="720"></canvas>
+  </div>
+
+  <div class="tabs-container">
+    <div class="tabs">
+      <button class="tab-button active" data-tab="about">About</button>
+      <button class="tab-button" data-tab="howto">操作説明</button>
+    </div>
+
+    <div id="about" class="tab-content active">
+      <h3>Lexi Blaster とは？</h3>
+      <p>
+        Lexi Blaster は、英語の語彙をゲームで楽しく学べる無料Webアプリです。<br>
+        CEFR A1〜C1 を中心に、<strong>約5,000語</strong>を収録。タイピングで隕石を撃ち落とすプレイにより、
+        想起 → 綴り → 即時フィードバックのサイクルを短時間で回せるように設計されています。
+      </p>
+      <ul>
+        <li><strong>完全無料・登録不要</strong></li>
+        <li>収録単語数：<strong>約5,000語</strong>（今後拡張予定）</li>
+        <li>ランキング機能（レベル帯/モードに対応）</li>
+        <li>アップデート予定：熟語・例文・発音練習モードの拡張</li>
+      </ul>
+    </div>
+
+    <div id="howto" class="tab-content">
+      <h3>操作説明</h3>
+      <ol>
+        <li>スタートボタンでゲーム開始</li>
+        <li>表示された意味/ヒントに合う英単語を正確にタイプ</li>
+        <li>正解で撃破＆コンボ加算／ミスでスコア減少</li>
+        <li>終了後にスコア送信 → ランキング登録</li>
+      </ol>
+      <p>※ PC推奨。モバイルは表示・説明の閲覧を中心に対応中です。</p>
+    </div>
   </div>
 
   <!-- 共有ボタン（ゲーム終了時に表示） -->
@@ -104,13 +137,8 @@
     <button id="cookie-open-settings" class="linklike">Cookie設定</button>
   </div>
 
-  <!-- 広告プレースホルダ（中身は後で管理画面のタグを入れる） -->
-  <div class="ad-area" aria-label="広告エリア">
-    <div class="ad-row">
-      <div class="ad-slot" id="ad-left"><span class="ad-ph">AD 300×250 / 320×50 / 728×90 など</span></div>
-      <div class="ad-slot" id="ad-right"><span class="ad-ph">AD 300×250 / 320×50 / 728×90 など</span></div>
-    </div>
-  </div>
+  <!-- 審査中プレースホルダ（表示は最小限） -->
+  <div class="ad-placeholder" aria-hidden="true" style="display:none;"></div>
 
   <!-- モバイル非対応オーバーレイ -->
   <div id="unsupported-overlay" class="unsupported-overlay" hidden>
@@ -181,6 +209,29 @@
   ></script>
 
   <script src="main.js" defer></script>
-  <script src="ads-loader.js" defer></script>
+
+  <style>
+    .tabs-container { margin-top: 20px; }
+    .tabs { display: flex; gap: 10px; flex-wrap: wrap; }
+    .tab-button { padding: 8px 16px; border-radius: 6px; border: 1px solid #ddd; background: #f4f4f4; cursor: pointer; }
+    .tab-button.active { background: #4c8bf5; color: #fff; border-color: #4c8bf5; }
+    .tab-content { display: none; margin-top: 16px; }
+    .tab-content.active { display: block; }
+  </style>
+
+  <script>
+    (function () {
+      var buttons = document.querySelectorAll('.tab-button');
+      var contents = document.querySelectorAll('.tab-content');
+      buttons.forEach(function(btn){
+        btn.addEventListener('click', function(){
+          buttons.forEach(function(b){ b.classList.remove('active'); });
+          contents.forEach(function(c){ c.classList.remove('active'); });
+          btn.classList.add('active');
+          document.getElementById(btn.dataset.tab).classList.add('active');
+        });
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/partials/header.html
+++ b/partials/header.html
@@ -5,6 +5,7 @@
     <a class="link" data-path="/lexiblaster/"   href="/lexiblaster/">Lexi Blaster</a>
     <a class="link" data-path="/leaderboard/"   href="/leaderboard/">ランキング</a>
     <a class="link" data-path="/changelog/"     href="/changelog/">更新履歴</a>
+    <a class="link" data-path="/terms/"         href="/terms/">Terms</a>
     <a class="link" data-path="/privacy/"       href="/privacy/">プライバシー</a>
     <a class="link" data-path="/cookie-policy/" href="/cookie-policy/">クッキー</a>
     <a class="link" data-path="/contact/"       href="/contact/">お問い合わせ</a>

--- a/terms/index.html
+++ b/terms/index.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>利用規約 | Irori's Toybox</title>
+<meta name="description" content="irori-toybox.com の利用規約。" />
+<link rel="preload" href="/assets/owner_icon.svg" as="image">
+<link rel="stylesheet" href="/assets/site.css">
+<script src="/assets/load-header.js" defer></script>
+<style>
+  body{
+    margin:0;
+    background: radial-gradient(1200px 600px at 20% -10%, #0e2436 0%, transparent 60%),
+                radial-gradient(900px 500px at 100% 0%, #0a2132 0%, transparent 60%),
+                var(--bg, #0b1520);
+    color: var(--txt, #e6f2ff);
+    font: 16px/1.7 system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    letter-spacing: .02em;
+  }
+  main{ width:min(1000px,92vw); margin:0 auto; padding:32px 0 64px; }
+  .terms-container { display:flex; gap:32px; align-items:flex-start; }
+  .terms-content { flex:3; min-width:0; }
+  .terms-content h2{ margin-top:0; }
+  .terms-content ul{ padding-left:20px; }
+  .sidebar {
+    flex:1;
+    background:#f7f7f7;
+    color:#1a1a1a;
+    padding:16px;
+    border-radius:10px;
+    box-shadow:0 10px 30px rgba(0,0,0,.25);
+  }
+  .sidebar a{ color:#0b4bb3; }
+  .owner-icon { width:72px; height:72px; border-radius:50%; object-fit:cover; display:block; margin-bottom:12px; }
+  footer{ width:min(1000px,92vw); margin:0 auto 32px; color:var(--muted, #9ab6c9); border-top:1px solid rgba(255,255,255,.08); padding-top:16px; font-size:.9em; }
+  @media (max-width: 768px){
+    .terms-container { flex-direction:column; }
+    .sidebar { width:100%; }
+  }
+</style>
+</head>
+<body>
+<header class="site" id="site-header" hidden></header>
+<main>
+  <div class="terms-container">
+    <article class="terms-content">
+      <h2>利用規約</h2>
+      <p>本規約は、irori-toybox.com（以下「本サイト」）が提供する各種コンテンツおよびサービス（以下「本サービス」）の利用条件を定めるものです。</p>
+
+      <h3>第1条（適用）</h3>
+      <p>本規約は、利用者と運営者との間の本サービスの利用に関わる一切の関係に適用されます。</p>
+
+      <h3>第2条（禁止事項）</h3>
+      <ul>
+        <li>法令または公序良俗に反する行為</li>
+        <li>本サービスの運営を妨げる行為</li>
+        <li>自動化ツール等によるスコア改ざん</li>
+      </ul>
+
+      <h3>第3条（免責事項）</h3>
+      <p>本サイトは、提供するコンテンツの正確性・完全性を保証するものではありません。利用者が本サービスを利用して生じたいかなる損害についても、運営者は一切の責任を負いません。</p>
+
+      <h3>第4条（知的財産権）</h3>
+      <p>
+        本サイトおよび本サービスに含まれるプログラム、テキスト、画像、ドット絵、音声、音楽（BGM/SE）、
+        UI デザイン、ロゴ、その他一切のコンテンツに関する知的財産権は、運営者または正当な権利者に帰属します。
+        ユーザーは、運営者の事前の書面による許可なく、これらのコンテンツを複製、転載、頒布、改変、公衆送信、
+        二次利用（ゲーム素材としての流用を含む）することはできません。
+      </p>
+      <p>
+        スクリーンショットやプレイ動画の投稿（いわゆる「プレイ配信」）については、
+        非商用かつ本サービスの紹介目的に限り許可します。ただし、コンテンツの実質的な抽出・再配布、
+        または素材単体の取り出し・配布はこれに含まれません。個別の事例についてはお問い合わせください。
+      </p>
+      <p>本サービス名、ロゴその他の標章は商標または商標に準ずる表示です。無断使用を禁じます。</p>
+
+      <h3>第5条（規約の変更）</h3>
+      <p>運営者は、必要と判断した場合には、利用者に通知することなく本規約を変更できるものとします。</p>
+
+      <h3>第6条（準拠法・裁判管轄）</h3>
+      <p>本規約の準拠法は日本法とし、本サービスに関して紛争が生じた場合には、運営者の所在地を管轄する裁判所を第一審の専属的合意管轄とします。</p>
+    </article>
+
+    <aside class="sidebar">
+      <img src="/assets/owner_icon.svg" alt="運営者アイコン" class="owner-icon">
+      <h3>運営者情報</h3>
+      <p>
+        名前：IRORI（個人開発）<br>
+        連絡先：X（DM のみ）<br>
+        <a href="https://x.com/irori_toybox" target="_blank" rel="noopener">Xプロフィールへ</a>
+      </p>
+    </aside>
+  </div>
+</main>
+<footer>
+  <p>© Irori's Toybox</p>
+</footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- expand the home page metadata and add an overview section that highlights the 5,000-word, free Lexi Blaster experience
- add About/操作説明 tabs beneath the Lexi Blaster canvas with supporting copy and remove live ad integrations in favor of a hidden placeholder
- introduce a dedicated terms page with an operator info sidebar and ensure the global navigation (and fallback header) links to it
- replace the operator profile image with an SVG asset to avoid bundling binary files

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e88a8e97a4832bae712dcc3588f403